### PR TITLE
refactor(Utils): change architecture for consistency

### DIFF
--- a/chores/chore.ts
+++ b/chores/chore.ts
@@ -1,19 +1,18 @@
 import shell from "shelljs";
 import chalk from "chalk";
 
-export default {
-    require(...command: string[]) {
-        const missings: string[] = command.filter((cmd) => !shell.which(cmd));
+export function need(...command: string[]) {
+    const missings: string[] = command.filter((cmd) => !shell.which(cmd));
 
-        if (missings.length !== 0) {
-            shell.echo(`Sorry, this script requires ${missings.join(", ")}`);
-            shell.exit(1);
-        }
-    },
-    exec(name: string, command: string) {
-        console.log(chalk.blue(name));
-        const res = shell.exec(command);
-        if (res.code !== 0) shell.exit(1);
-        return res;
-    },
-};
+    if (missings.length !== 0) {
+        shell.echo(`Sorry, this script requires ${missings.join(", ")}`);
+        shell.exit(1);
+    }
+}
+
+export function exec(name: string, command: string) {
+    console.log(chalk.blue(name));
+    const res = shell.exec(command);
+    if (res.code !== 0) shell.exit(1);
+    return res;
+}

--- a/chores/release.ts
+++ b/chores/release.ts
@@ -9,9 +9,9 @@
 // git push
 
 import shell from "shelljs";
-import chore from "./chore";
+import { need, exec } from "./chore";
 
-chore.require("git", "npm");
+need("git", "npm");
 
 const [, , semver] = process.argv;
 
@@ -20,16 +20,13 @@ if (!["major", "minor", "patch"].includes(semver)) {
     shell.exit(1);
 }
 
-chore.exec("pull master", "git checkout master && git pull");
-chore.exec("bump version", `npm --no-git-tag-version version ${semver}`);
+exec("pull master", "git checkout master && git pull");
+exec("bump version", `npm --no-git-tag-version version ${semver}`);
 
 import { version } from "../package.json";
 
-chore.exec(
-    "commit & push",
-    `git commit -A "bump version to ${version}" && git push`
-);
-chore.exec(
+exec("commit & push", `git commit -A "bump version to ${version}" && git push`);
+exec(
     "merge master on stable & pull",
     "git checkout stable && git pull && git merge master && git push"
 );

--- a/src/commands/list.cmd.ts
+++ b/src/commands/list.cmd.ts
@@ -1,6 +1,6 @@
 import { MessageEmbed } from "discord.js";
 import { makeCommand } from "../other/makeCommand";
-import { ListUtils } from "../other/ListUtils";
+import { getListRawData } from "../other/ListUtils";
 import { reply } from "../utils/reply";
 
 const cmd = makeCommand("list", {
@@ -16,7 +16,7 @@ const cmd = makeCommand("list", {
 });
 
 cmd.executor = async (_a, { detail }, { commandSet, options, message }) => {
-    const raw = ListUtils.getRawListData(commandSet, options.localization);
+    const raw = getListRawData(commandSet, options.localization);
     let commands = options.devIDs.includes(message.author.id)
         ? raw.commands
         : raw.commands.filter((c) => !c.command.devOnly);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export { Localization } from "./models/localization/Localization";
 export type PartialParseOptions = DeepPartial<ParseOptions>;
 
 export * as HelpUtils from "./other/HelpUtils";
-export { ListUtils } from "./other/ListUtils";
+export * as ListUtils from "./other/ListUtils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export type PartialParseOptions = DeepPartial<ParseOptions>;
 
 export * as HelpUtils from "./other/HelpUtils";
 export * as ListUtils from "./other/ListUtils";
+
+export { enableDebugLogs } from "./logger";

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,5 @@ export { Localization } from "./models/localization/Localization";
 
 export type PartialParseOptions = DeepPartial<ParseOptions>;
 
-export { HelpUtils } from "./other/HelpUtils";
+export * as HelpUtils from "./other/HelpUtils";
 export { ListUtils } from "./other/ListUtils";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,36 +9,40 @@ const levels = {
 };
 
 /** @internal */
-export abstract class Logger {
-    public static enableDebug = false;
+let enableDebug = false;
 
-    private static _log(level: keyof typeof levels, ...args: any[]) {
-        const log =
-            level === "error"
-                ? console.error
-                : level === "warn"
-                ? console.warn
-                : console.log;
-        log(
-            chalk.bold(chalk.blue("[discord-bot-cli]"), levels[level]),
-            ...args
-        );
-    }
-
-    static debug(...args: any[]) {
-        if (!Logger.enableDebug) return;
-        Logger._log("debug", ...args);
-    }
-
-    static log(...args: any[]) {
-        Logger._log("log", ...args);
-    }
-
-    static warn(...args: any[]) {
-        Logger._log("warn", ...args);
-    }
-
-    static error(...args: any[]) {
-        Logger._log("error", ...args);
-    }
+/** @internal */
+function print(level: keyof typeof levels, ...args: any[]) {
+    const log =
+        level === "error"
+            ? console.error
+            : level === "warn"
+            ? console.warn
+            : console.log;
+    log(chalk.bold(chalk.blue("[discord-bot-cli]"), levels[level]), ...args);
 }
+
+/**
+ * Enable or disable logs with `debug` level.
+ * @param enable - Default is `true`
+ */
+export function enableDebugLogs(enable = true) {
+    enableDebug = enable;
+}
+
+/** @internal */
+export const Logger = Object.freeze({
+    debug(...args: any[]) {
+        if (!enableDebug) return;
+        print("debug", ...args);
+    },
+    log(...args: any[]) {
+        print("log", ...args);
+    },
+    warn(...args: any[]) {
+        print("warn", ...args);
+    },
+    error(...args: any[]) {
+        print("error", ...args);
+    },
+});

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -29,7 +29,7 @@ import { ParsableType } from "./ParsableType";
 import { ThrottlingDefinition } from "./definition/ThrottlingDefinition";
 import { Throttler } from "./Throttler";
 import { CommandLoadError } from "./errors/CommandLoadError";
-import { HelpUtils } from "../other/HelpUtils";
+import { defaultHelp } from "../other/HelpUtils";
 
 export class Command {
     private readonly _throttler: Throttler | null | undefined;
@@ -239,7 +239,7 @@ export class Command {
         } else if (this.commandSet.helpHandler) {
             await this.commandSet.helpHandler(this, context);
         } else {
-            await HelpUtils.DefaultHelp(this, context);
+            await defaultHelp(this, context);
         }
     }
 

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -23,7 +23,7 @@ import {
     CommandCollection,
 } from "./CommandCollection";
 import { CanUseCommandCb } from "./callbacks/CanUseCommandCb";
-import { HelpCb } from "./callbacks/HelpCb";
+import { HelpHandler } from "./callbacks/HelpHandler";
 import { parseValue } from "../other/parsing/parseValue";
 import { ParsableType } from "./ParsableType";
 import { ThrottlingDefinition } from "./definition/ThrottlingDefinition";
@@ -52,7 +52,7 @@ export class Command {
         private readonly _flagsShortcuts: ReadonlyMap<Char, string>,
         private readonly _executor: CommandExecutor<any> | undefined,
         private readonly _canUse: CanUseCommandCb | undefined,
-        private readonly _help: HelpCb | undefined,
+        private readonly _help: HelpHandler | undefined,
         throttling: ThrottlingDefinition | null | undefined,
         private readonly _useThrottlerOnSubs: boolean,
         public readonly ignored: boolean,
@@ -87,7 +87,7 @@ export class Command {
         commandSet: CommandSet,
         data: CommandData<T>,
         parent: Command | null,
-        parentHelp: HelpCb | undefined
+        parentHelp: HelpHandler | undefined
     ): Command {
         function resolveInheritance<K extends keyof Command>(
             prop: K,

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -17,7 +17,7 @@ import { parseFlags } from "../other/parsing/parseFlags";
 import { parseArgs } from "../other/parsing/parseArgs";
 import { RestDefinition } from "./definition/RestDefinition";
 import { CommandResultUtils } from "./CommandResult";
-import { CommandResultError } from "./CommandResultError";
+import { CommandResultError } from "./errors/CommandResultError";
 import {
     ReadonlyCommandCollection,
     CommandCollection,

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -22,7 +22,7 @@ import {
     ReadonlyCommandCollection,
     CommandCollection,
 } from "./CommandCollection";
-import { CanUseCommandCb } from "./callbacks/CanUseCommandCb";
+import { CanUseCommandHandler } from "./callbacks/CanUseCommandHandler";
 import { HelpHandler } from "./callbacks/HelpHandler";
 import { parseValue } from "../other/parsing/parseValue";
 import { ParsableType } from "./ParsableType";
@@ -51,7 +51,7 @@ export class Command {
         public readonly flags: ReadonlyMap<string, FlagDefinition>,
         private readonly _flagsShortcuts: ReadonlyMap<Char, string>,
         private readonly _executor: CommandExecutor<any> | undefined,
-        private readonly _canUse: CanUseCommandCb | undefined,
+        private readonly _canUse: CanUseCommandHandler | undefined,
         private readonly _help: HelpHandler | undefined,
         throttling: ThrottlingDefinition | null | undefined,
         private readonly _useThrottlerOnSubs: boolean,

--- a/src/models/CommandResult.ts
+++ b/src/models/CommandResult.ts
@@ -56,59 +56,38 @@ export type CommandResult =
       ));
 
 /** @internal */
-export abstract class CommandResultUtils {
-    /** @internal */
-    static ok(command: Command, result: any): CommandResult {
+export const CommandResultUtils = Object.freeze({
+    ok(command: Command, result: any): CommandResult {
         return { status: "ok", command, result };
-    }
-
-    /** @internal */
-    static error(error: any): CommandResult {
+    },
+    error(error: any): CommandResult {
         return { status: "error", error };
-    }
-
-    /** @internal */
-    static noExecutor(command: Command): CommandResult {
+    },
+    noExecutor(command: Command): CommandResult {
         return { status: "no executor", command };
-    }
-
-    /** @internal */
-    static devOnly(command: Command): CommandResult {
+    },
+    devOnly(command: Command): CommandResult {
         return { status: "dev only", command };
-    }
-
-    /** @internal */
-    static guildOnly(command: Command): CommandResult {
+    },
+    guildOnly(command: Command): CommandResult {
         return { status: "guild only", command };
-    }
-
-    /** @internal */
-    static unauthorizedUser(command: Command): CommandResult {
+    },
+    unauthorizedUser(command: Command): CommandResult {
         return { status: "unauthorized user", command };
-    }
-
-    /** @internal */
-    static throttling(command: Command): CommandResult {
+    },
+    throttling(command: Command): CommandResult {
         return { status: "throttling", command };
-    }
-
-    /** @internal */
-    static clientPermissions(command: Command): CommandResult {
+    },
+    clientPermissions(command: Command): CommandResult {
         return { status: "client permissions", command };
-    }
-
-    /** @internal */
-    static notPrefixed(): CommandResult {
+    },
+    notPrefixed(): CommandResult {
         return { status: "not prefixed" };
-    }
-
-    /** @internal */
-    static commandNotFound(): CommandResult {
+    },
+    commandNotFound(): CommandResult {
         return { status: "command not found" };
-    }
-
-    /** @internal */
-    static failParseArgInvalid(
+    },
+    failParseArgInvalid(
         arg: Readonly<ArgDefinition>,
         got: string
     ): CommandResult {
@@ -119,30 +98,24 @@ export abstract class CommandResultUtils {
             reason: "invalid value",
             got,
         };
-    }
-
-    /** @internal */
-    static failParseArgMissing(arg: Readonly<ArgDefinition>): CommandResult {
+    },
+    failParseArgMissing(arg: Readonly<ArgDefinition>): CommandResult {
         return {
             status: "parsing error",
             type: "arg",
             arg,
             reason: "missing argument",
         };
-    }
-
-    /** @internal */
-    static failParseFlagUnknown(name: string): CommandResult {
+    },
+    failParseFlagUnknown(name: string): CommandResult {
         return {
             status: "parsing error",
             type: "flag",
             reason: "unknown flag",
             name,
         };
-    }
-
-    /** @internal */
-    static failParseFlagInvalid(
+    },
+    failParseFlagInvalid(
         flag: Readonly<FlagDefinition>,
         got: string
     ): CommandResult {
@@ -153,5 +126,5 @@ export abstract class CommandResultUtils {
             reason: "invalid value",
             got,
         };
-    }
-}
+    },
+});

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -24,13 +24,13 @@ import {
 } from "../utils/PathUtils";
 import chalk from "chalk";
 import { CommandLoadError } from "./errors/CommandLoadError";
-import { HelpCb } from "./callbacks/HelpCb";
+import { HelpHandler } from "./callbacks/HelpHandler";
 
 type BuildInCommand = "help" | "list" | "cmd";
 
 export class CommandSet {
     private _commands = new CommandCollection();
-    public helpHandler: HelpCb | undefined = undefined;
+    public helpHandler: HelpHandler | undefined = undefined;
 
     constructor(private _defaultOptions?: DeepPartial<ParseOptions>) {}
 

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -11,7 +11,7 @@ import { ParseOptions } from "./ParseOptions";
 import defaultLocalization from "../data/localization.json";
 import { deepMerge } from "../utils/deepMerge";
 import { DeepPartial } from "../utils/DeepPartial";
-import { HelpUtils } from "../other/HelpUtils";
+import { commandFullName } from "../other/HelpUtils";
 import { template } from "../utils/template";
 import { CommandResultError } from "./CommandResultError";
 import {
@@ -198,7 +198,7 @@ export class CommandSet {
         if (command.guildOnly && !message.guild) {
             await message.reply(
                 template(opts.localization.misc.guildOnlyWarning, {
-                    command: HelpUtils.Command.getFullName(command),
+                    command: commandFullName(command),
                 })
             );
             return CommandResultUtils.guildOnly(command);

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -18,7 +18,10 @@ import {
     CommandCollection,
     ReadonlyCommandCollection,
 } from "./CommandCollection";
-import PathUtils from "../utils/PathUtils";
+import {
+    relativeFromEntryPoint,
+    resolveFromEntryPoint,
+} from "../utils/PathUtils";
 import chalk from "chalk";
 import { CommandLoadError } from "./errors/CommandLoadError";
 import { HelpCb } from "./callbacks/HelpCb";
@@ -36,9 +39,7 @@ export class CommandSet {
     }
 
     private _loadFile(path: string) {
-        const debugPath = chalk.underline(
-            PathUtils.relativeFromEntryPoint(path)
-        );
+        const debugPath = chalk.underline(relativeFromEntryPoint(path));
         Logger.debug(`Load command from ${debugPath}`);
         try {
             const command = Command.load(path, this);
@@ -70,7 +71,7 @@ export class CommandSet {
      */
     loadCommands(commandDirPath: string, includeTS = false) {
         try {
-            commandDirPath = PathUtils.resolveFromEntryPoint(commandDirPath);
+            commandDirPath = resolveFromEntryPoint(commandDirPath);
             const cmdFiles = fs
                 .readdirSync(commandDirPath)
                 .filter(

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -13,7 +13,7 @@ import { deepMerge } from "../utils/deepMerge";
 import { DeepPartial } from "../utils/DeepPartial";
 import { commandFullName } from "../other/HelpUtils";
 import { template } from "../utils/template";
-import { CommandResultError } from "./CommandResultError";
+import { CommandResultError } from "./errors/CommandResultError";
 import {
     CommandCollection,
     ReadonlyCommandCollection,

--- a/src/models/callbacks/CanUseCommandHandler.ts
+++ b/src/models/callbacks/CanUseCommandHandler.ts
@@ -1,6 +1,6 @@
 import { User, Message } from "discord.js";
 
-export type CanUseCommandCb = (
+export type CanUseCommandHandler = (
     user: User,
     message: Message
 ) => boolean | string;

--- a/src/models/callbacks/HelpHandler.ts
+++ b/src/models/callbacks/HelpHandler.ts
@@ -3,7 +3,7 @@ import { Command } from "../Command";
 import { ParseOptions } from "../ParseOptions";
 import { CommandSet } from "../CommandSet";
 
-export type HelpCb = (
+export type HelpHandler = (
     command: Command,
     context: {
         message: Message;

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -3,7 +3,7 @@ import { ArgDefinition } from "./ArgDefinition";
 import { FlagDefinition } from "./FlagDefinition";
 import { RestDefinition } from "./RestDefinition";
 import { CanUseCommandCb } from "../callbacks/CanUseCommandCb";
-import { HelpCb } from "../callbacks/HelpCb";
+import { HelpHandler } from "../callbacks/HelpHandler";
 import { ThrottlingDefinition } from "./ThrottlingDefinition";
 
 export type CommandDefinition = {
@@ -39,7 +39,7 @@ export type CommandDefinition = {
     /**
      * If defined, this callback is called when help is needed for this command instead of default help.
      */
-    readonly help?: HelpCb;
+    readonly help?: HelpHandler;
     /**
      * If set to true and `help` is defined, this command's `help` handler is used for sub command that not defined a `help` handler.
      * (default is false)

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -2,7 +2,7 @@ import { PermissionString } from "discord.js";
 import { ArgDefinition } from "./ArgDefinition";
 import { FlagDefinition } from "./FlagDefinition";
 import { RestDefinition } from "./RestDefinition";
-import { CanUseCommandCb } from "../callbacks/CanUseCommandCb";
+import { CanUseCommandHandler } from "../callbacks/CanUseCommandHandler";
 import { HelpHandler } from "../callbacks/HelpHandler";
 import { ThrottlingDefinition } from "./ThrottlingDefinition";
 
@@ -34,7 +34,7 @@ export type CommandDefinition = {
      * If the result is true, the command is executed.
      * If the result is a string, the command is not executed and a reply message with the string is returned.
      */
-    readonly canUse?: CanUseCommandCb;
+    readonly canUse?: CanUseCommandHandler;
 
     /**
      * If defined, this callback is called when help is needed for this command instead of default help.

--- a/src/models/errors/CommandResultError.ts
+++ b/src/models/errors/CommandResultError.ts
@@ -1,4 +1,4 @@
-import { CommandResult } from "./CommandResult";
+import { CommandResult } from "../CommandResult";
 
 /** @internal */
 export class CommandResultError extends Error {

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -10,7 +10,7 @@ import { FlagRawHelp } from "../models/data/help/FlagRawHelp";
 import { RestRawHelp } from "../models/data/help/RestRawHelp";
 import { CommandLocalization } from "../models/localization/CommandLocalization";
 import { ParseOptions } from "../models/ParseOptions";
-import { ArrayUtils } from "../utils/array";
+import { isArray } from "../utils/array";
 import { template } from "../utils/template";
 import { reply } from "../utils/reply";
 
@@ -65,7 +65,7 @@ export function commandRawHelp(
             command.rest.description ??
             "";
         const usageString = `[...${name}]`;
-        const typeNames = ArrayUtils.isArray(command.rest.type)
+        const typeNames = isArray(command.rest.type)
             ? command.rest.type.map((t) => localization.typeNames[t])
             : [localization.typeNames[command.rest.type]];
         rest = { name, description, usageString, typeNames };
@@ -95,7 +95,7 @@ function argRawHelp(
     typeNamesLocalization: TypeNameLocalization
 ): ArgumentRawHelp {
     const argLocalization = (localization.args ?? {})[name] ?? {};
-    const typeNames = ArrayUtils.isArray(arg.type)
+    const typeNames = isArray(arg.type)
         ? arg.type.map((t) => typeNamesLocalization[t])
         : [typeNamesLocalization[arg.type]];
     const localizedName = argLocalization.name ?? name;
@@ -125,7 +125,7 @@ function flagRawHelp(
     typeNamesLocalization: TypeNameLocalization
 ): FlagRawHelp {
     const flagLocalization = (localization.flags ?? {})[name] ?? {};
-    const typeNames = ArrayUtils.isArray(flag.type)
+    const typeNames = isArray(flag.type)
         ? flag.type.map((t) => typeNamesLocalization[t])
         : [typeNamesLocalization[flag.type]];
     const localizedName = flagLocalization.name ?? name;

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -1,4 +1,4 @@
-import { Command } from "../models/Command"; /* eslint-disable-line @typescript-eslint/no-unused-vars */ // due to namespace Command: will be remove in future
+import { Command } from "../models/Command";
 import { Localization } from "../models/localization/Localization";
 import { MessageEmbed, Message } from "discord.js";
 import { TypeNameLocalization } from "../models/localization/TypeNameLocalization";
@@ -9,296 +9,247 @@ import { ArgumentRawHelp } from "../models/data/help/ArgumentRawHelp";
 import { FlagRawHelp } from "../models/data/help/FlagRawHelp";
 import { RestRawHelp } from "../models/data/help/RestRawHelp";
 import { CommandLocalization } from "../models/localization/CommandLocalization";
+import { ParseOptions } from "../models/ParseOptions";
 import { ArrayUtils } from "../utils/array";
 import { template } from "../utils/template";
 import { reply } from "../utils/reply";
-import { ParseOptions } from "../models/ParseOptions";
 
-// TODO: remove namespace for HelpUtils and Command
-// replace by a single class CommandHelp
-// breaking change !
+export async function defaultHelp(
+    command: Command,
+    { message, options }: { message: Message; options: ParseOptions }
+) {
+    const embed = embedHelp(
+        command,
+        options.prefix,
+        options.localization,
+        message
+    );
+    await reply(message, { embed });
+}
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace HelpUtils {
-    export async function DefaultHelp(
-        command: Command,
-        { message, options }: { message: Message; options: ParseOptions }
-    ) {
-        const embed = HelpUtils.Command.embedHelp(
-            command,
-            options.prefix,
-            options.localization,
-            message
+export function commandFullName(command: Command) {
+    return command
+        .getParents()
+        .map((cmd) => cmd.name)
+        .join(" ");
+}
+
+export function commandRawHelp(
+    command: Command,
+    localization: Localization
+): CommandRawHelp {
+    const commandLocalization = localization.commands[command.name] ?? {};
+    const fullName = commandFullName(command);
+    const description = commandLocalization.description ?? command.description;
+
+    const collection = command.parent?.subs ?? command.commandSet.commands;
+    const aliases = command.aliases.filter((a) => collection.hasAlias(a));
+
+    const args = Array.from(command.args.entries()).map(([name, arg]) =>
+        argRawHelp(arg, name, commandLocalization, localization.typeNames)
+    );
+
+    const flags = Array.from(command.flags.entries()).map(([name, flag]) =>
+        flagRawHelp(flag, name, commandLocalization, localization.typeNames)
+    );
+
+    const subs = Array.from(command.subs.values()).map((c) =>
+        commandRawHelp(c, localization)
+    );
+
+    let rest: RestRawHelp | undefined = undefined;
+    if (command.rest) {
+        const name = commandLocalization?.rest?.name ?? command.rest.name;
+        const description =
+            commandLocalization?.rest?.description ??
+            command.rest.description ??
+            "";
+        const usageString = `[...${name}]`;
+        const typeNames = ArrayUtils.isArray(command.rest.type)
+            ? command.rest.type.map((t) => localization.typeNames[t])
+            : [localization.typeNames[command.rest.type]];
+        rest = { name, description, usageString, typeNames };
+    }
+
+    const tags: string[] = [];
+    if (command.devOnly) tags.push(localization.help.tags.devOnly);
+    if (command.guildOnly) tags.push(localization.help.tags.guildOnly);
+
+    return {
+        command,
+        fullName,
+        aliases,
+        description,
+        args,
+        flags,
+        subs,
+        rest,
+        tags,
+    };
+}
+
+function argRawHelp(
+    arg: ArgDefinition,
+    name: string,
+    localization: CommandLocalization,
+    typeNamesLocalization: TypeNameLocalization
+): ArgumentRawHelp {
+    const argLocalization = (localization.args ?? {})[name] ?? {};
+    const typeNames = ArrayUtils.isArray(arg.type)
+        ? arg.type.map((t) => typeNamesLocalization[t])
+        : [typeNamesLocalization[arg.type]];
+    const localizedName = argLocalization.name ?? name;
+    const description = argLocalization.description ?? arg.description ?? "";
+    let usageString: string;
+    if (arg.optional) {
+        const defaultValue = arg.defaultValue ? ` = ${arg.defaultValue}` : "";
+        usageString = `[${localizedName}${defaultValue}]`;
+    } else {
+        usageString = `<${localizedName}>`;
+    }
+
+    return {
+        arg,
+        typeNames: typeNames,
+        name,
+        localizedName,
+        description,
+        usageString,
+    };
+}
+
+function flagRawHelp(
+    flag: FlagDefinition,
+    name: string,
+    localization: CommandLocalization,
+    typeNamesLocalization: TypeNameLocalization
+): FlagRawHelp {
+    const flagLocalization = (localization.flags ?? {})[name] ?? {};
+    const typeNames = ArrayUtils.isArray(flag.type)
+        ? flag.type.map((t) => typeNamesLocalization[t])
+        : [typeNamesLocalization[flag.type]];
+    const localizedName = flagLocalization.name ?? name;
+    const description = flagLocalization.description ?? flag.description ?? "";
+    const longUsageString = `--${name}`;
+    const shortUsageString = flag.shortcut ? `-${flag.shortcut}` : undefined;
+
+    return {
+        flag,
+        typeNames,
+        name,
+        localizedName,
+        description,
+        longUsageString,
+        shortUsageString,
+    };
+}
+
+function embedHelp(
+    command: Command,
+    prefix: string,
+    localization: Localization,
+    message?: Message
+) {
+    const rawHelp = commandRawHelp(command, localization);
+
+    const embed = new MessageEmbed()
+        .setTitle(rawHelp.fullName)
+        .setDescription(
+            rawHelp.description +
+                (rawHelp.tags.length === 0
+                    ? ""
+                    : "\n\n" + rawHelp.tags.map((t) => `\`${t}\``).join(" "))
         );
-        await reply(message, { embed });
+
+    if (command.hasExecutor) {
+        const usageString =
+            prefix +
+            rawHelp.fullName +
+            (rawHelp.args.length === 0
+                ? ""
+                : " " + rawHelp.args.map((a) => a.usageString).join(" ")) +
+            (rawHelp.rest ? " " + rawHelp.rest.usageString : "");
+        embed.addField(
+            localization.help.usage,
+            `**\`${usageString}\`**` +
+                (rawHelp.args.length !== 0
+                    ? `\n\n${localization.help.argUsageHint}`
+                    : ""),
+            false
+        );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-namespace
-    export namespace Command {
-        export function getFullName(command: Command) {
-            return command
-                .getParents()
-                .map((cmd) => cmd.name)
-                .join(" ");
-        }
-
-        export function getRawHelp(
-            command: Command,
-            localization: Localization
-        ): CommandRawHelp {
-            const commandLocalization =
-                localization.commands[command.name] ?? {};
-            const fullName = getFullName(command);
-            const description =
-                commandLocalization.description ?? command.description;
-
-            const collection =
-                command.parent?.subs ?? command.commandSet.commands;
-            const aliases = command.aliases.filter((a) =>
-                collection.hasAlias(a)
-            );
-
-            const args = Array.from(command.args.entries()).map(([name, arg]) =>
-                Arg.getRawHelp(
-                    arg,
-                    name,
-                    commandLocalization,
-                    localization.typeNames
-                )
-            );
-
-            const flags = Array.from(
-                command.flags.entries()
-            ).map(([name, flag]) =>
-                Flag.getRawHelp(
-                    flag,
-                    name,
-                    commandLocalization,
-                    localization.typeNames
-                )
-            );
-
-            const subs = Array.from(command.subs.values()).map((c) =>
-                getRawHelp(c, localization)
-            );
-
-            let rest: RestRawHelp | undefined = undefined;
-            if (command.rest) {
-                const name =
-                    commandLocalization?.rest?.name ?? command.rest.name;
-                const description =
-                    commandLocalization?.rest?.description ??
-                    command.rest.description ??
-                    "";
-                const usageString = `[...${name}]`;
-                const typeNames = ArrayUtils.isArray(command.rest.type)
-                    ? command.rest.type.map((t) => localization.typeNames[t])
-                    : [localization.typeNames[command.rest.type]];
-                rest = { name, description, usageString, typeNames };
-            }
-
-            const tags: string[] = [];
-            if (command.devOnly) tags.push(localization.help.tags.devOnly);
-            if (command.guildOnly) tags.push(localization.help.tags.guildOnly);
-
-            return {
-                command,
-                fullName,
-                aliases,
-                description,
-                args,
-                flags,
-                subs,
-                rest,
-                tags,
-            };
-        }
-
-        export function embedHelp(
-            command: Command,
-            prefix: string,
-            localization: Localization,
-            message?: Message
-        ) {
-            const rawHelp = getRawHelp(command, localization);
-
-            const embed = new MessageEmbed()
-                .setTitle(rawHelp.fullName)
-                .setDescription(
-                    rawHelp.description +
-                        (rawHelp.tags.length === 0
-                            ? ""
-                            : "\n\n" +
-                              rawHelp.tags.map((t) => `\`${t}\``).join(" "))
-                );
-
-            if (command.hasExecutor) {
-                const usageString =
-                    prefix +
-                    rawHelp.fullName +
-                    (rawHelp.args.length === 0
-                        ? ""
-                        : " " +
-                          rawHelp.args.map((a) => a.usageString).join(" ")) +
-                    (rawHelp.rest ? " " + rawHelp.rest.usageString : "");
-                embed.addField(
-                    localization.help.usage,
-                    `**\`${usageString}\`**` +
-                        (rawHelp.args.length !== 0
-                            ? `\n\n${localization.help.argUsageHint}`
-                            : ""),
-                    false
-                );
-            }
-
-            const args =
-                rawHelp.args
-                    .map(
-                        (a) =>
-                            `\`${a.name}\` *${a.typeNames.join(" | ")}*` +
-                            (a.description !== ""
-                                ? `\n⮩  ${a.description}`
-                                : "")
-                    )
-                    .join("\n") +
-                (rawHelp.rest
-                    ? `\n\`${rawHelp.rest.name}\` *${template(
-                          localization.help.restTypeName,
-                          { type: rawHelp.rest.typeNames.join(" | ") }
-                      )}*` +
-                      (rawHelp.rest.description !== ""
-                          ? `\n⮩  ${rawHelp.rest.description}`
-                          : "")
-                    : "");
-            if (args !== "")
-                embed.addField(localization.help.arguments, args, true);
-
-            const flags = rawHelp.flags
-                .map(
-                    (f) =>
-                        `\`--${f.name}\`` +
-                        (f.flag.shortcut ? ` \`-${f.flag.shortcut}\`` : "") +
-                        ` *${f.typeNames.join(" | ")}*` +
-                        (f.description !== "" ? `\n⮩  ${f.description}` : "")
-                )
-                .join("\n");
-            if (flags !== "")
-                embed.addField(localization.help.flags, flags, true);
-
-            const subs = (message
-                ? rawHelp.subs.filter((s) =>
-                      s.command.checkPermissions(message)
-                  )
-                : rawHelp.subs
+    const args =
+        rawHelp.args
+            .map(
+                (a) =>
+                    `\`${a.name}\` *${a.typeNames.join(" | ")}*` +
+                    (a.description !== "" ? `\n⮩  ${a.description}` : "")
             )
-                .map(
-                    (s) =>
-                        `\`${s.command.name}\`` +
-                        (s.description !== "" ? ` ${s.description}` : "")
-                )
-                .join("\n");
-            if (subs !== "")
-                embed.addField(localization.help.subCommands, subs, false);
+            .join("\n") +
+        (rawHelp.rest
+            ? `\n\`${rawHelp.rest.name}\` *${template(
+                  localization.help.restTypeName,
+                  { type: rawHelp.rest.typeNames.join(" | ") }
+              )}*` +
+              (rawHelp.rest.description !== ""
+                  ? `\n⮩  ${rawHelp.rest.description}`
+                  : "")
+            : "");
+    if (args !== "") embed.addField(localization.help.arguments, args, true);
 
-            const aliases = rawHelp.aliases.map((a) => `\`${a}\``).join(" ");
-            if (aliases !== "")
-                embed.addField(localization.help.aliases, aliases, false);
+    const flags = rawHelp.flags
+        .map(
+            (f) =>
+                `\`--${f.name}\`` +
+                (f.flag.shortcut ? ` \`-${f.flag.shortcut}\`` : "") +
+                ` *${f.typeNames.join(" | ")}*` +
+                (f.description !== "" ? `\n⮩  ${f.description}` : "")
+        )
+        .join("\n");
+    if (flags !== "") embed.addField(localization.help.flags, flags, true);
 
-            const clientPermissions = rawHelp.command.clientPermissions
-                .map((p) => `\`${p}\``)
-                .join(" ");
-            if (clientPermissions !== "")
-                embed.addField(
-                    localization.help.bot_permissions,
-                    clientPermissions,
-                    false
-                );
+    const subs = (message
+        ? rawHelp.subs.filter((s) => s.command.checkPermissions(message))
+        : rawHelp.subs
+    )
+        .map(
+            (s) =>
+                `\`${s.command.name}\`` +
+                (s.description !== "" ? ` ${s.description}` : "")
+        )
+        .join("\n");
+    if (subs !== "") embed.addField(localization.help.subCommands, subs, false);
 
-            if (rawHelp.command.userPermissions) {
-                const userPermissions = rawHelp.command.userPermissions
-                    .map((p) => `\`${p}\``)
-                    .join(" ");
-                if (userPermissions !== "")
-                    embed.addField(
-                        localization.help.user_permissions,
-                        userPermissions,
-                        false
-                    );
-            }
+    const aliases = rawHelp.aliases.map((a) => `\`${a}\``).join(" ");
+    if (aliases !== "")
+        embed.addField(localization.help.aliases, aliases, false);
 
-            const exemples = rawHelp.command.examples
-                .map((e) => `\`${e}\``)
-                .join("\n");
-            if (exemples !== "")
-                embed.addField(localization.help.examples, exemples, false);
+    const clientPermissions = rawHelp.command.clientPermissions
+        .map((p) => `\`${p}\``)
+        .join(" ");
+    if (clientPermissions !== "")
+        embed.addField(
+            localization.help.bot_permissions,
+            clientPermissions,
+            false
+        );
 
-            return embed;
-        }
+    if (rawHelp.command.userPermissions) {
+        const userPermissions = rawHelp.command.userPermissions
+            .map((p) => `\`${p}\``)
+            .join(" ");
+        if (userPermissions !== "")
+            embed.addField(
+                localization.help.user_permissions,
+                userPermissions,
+                false
+            );
     }
-}
 
-abstract class Arg {
-    static getRawHelp(
-        arg: ArgDefinition,
-        name: string,
-        localization: CommandLocalization,
-        typeNamesLocalization: TypeNameLocalization
-    ): ArgumentRawHelp {
-        const argLocalization = (localization.args ?? {})[name] ?? {};
-        const typeNames = ArrayUtils.isArray(arg.type)
-            ? arg.type.map((t) => typeNamesLocalization[t])
-            : [typeNamesLocalization[arg.type]];
-        const localizedName = argLocalization.name ?? name;
-        const description =
-            argLocalization.description ?? arg.description ?? "";
-        let usageString: string;
-        if (arg.optional) {
-            const defaultValue = arg.defaultValue
-                ? ` = ${arg.defaultValue}`
-                : "";
-            usageString = `[${localizedName}${defaultValue}]`;
-        } else {
-            usageString = `<${localizedName}>`;
-        }
+    const exemples = rawHelp.command.examples.map((e) => `\`${e}\``).join("\n");
+    if (exemples !== "")
+        embed.addField(localization.help.examples, exemples, false);
 
-        return {
-            arg,
-            typeNames: typeNames,
-            name,
-            localizedName,
-            description,
-            usageString,
-        };
-    }
-}
-
-abstract class Flag {
-    static getRawHelp(
-        flag: FlagDefinition,
-        name: string,
-        localization: CommandLocalization,
-        typeNamesLocalization: TypeNameLocalization
-    ): FlagRawHelp {
-        const flagLocalization = (localization.flags ?? {})[name] ?? {};
-        const typeNames = ArrayUtils.isArray(flag.type)
-            ? flag.type.map((t) => typeNamesLocalization[t])
-            : [typeNamesLocalization[flag.type]];
-        const localizedName = flagLocalization.name ?? name;
-        const description =
-            flagLocalization.description ?? flag.description ?? "";
-        const longUsageString = `--${name}`;
-        const shortUsageString = flag.shortcut
-            ? `-${flag.shortcut}`
-            : undefined;
-
-        return {
-            flag,
-            typeNames,
-            name,
-            localizedName,
-            description,
-            longUsageString,
-            shortUsageString,
-        };
-    }
+    return embed;
 }

--- a/src/other/ListUtils.ts
+++ b/src/other/ListUtils.ts
@@ -4,21 +4,19 @@ import { Command } from "../models/Command";
 import { CommandRawList } from "../models/data/list/CommandRawList";
 import { Localization } from "../models/localization/Localization";
 
-export abstract class ListUtils {
-    static getRawListData(
-        commandSet: CommandSet,
-        localization: Localization
-    ): ListRawData {
-        const commands = Array.from(commandSet.commands)
-            .sort((a, b) => {
-                if (a.name < b.name) return -1;
-                if (a.name > b.name) return 1;
-                return 0;
-            })
-            .map((c) => getCommandRaw(c, localization));
+export function getListRawData(
+    commandSet: CommandSet,
+    localization: Localization
+): ListRawData {
+    const commands = Array.from(commandSet.commands)
+        .sort((a, b) => {
+            if (a.name < b.name) return -1;
+            if (a.name > b.name) return 1;
+            return 0;
+        })
+        .map((c) => getCommandRaw(c, localization));
 
-        return { commands };
-    }
+    return { commands };
 }
 
 function getCommandRaw(

--- a/src/other/makeCommand.ts
+++ b/src/other/makeCommand.ts
@@ -1,7 +1,7 @@
 import { CommandDefinition } from "../models/definition/CommandDefinition";
 import { CommandData } from "../models/CommandData";
 import { ParsableTypeName } from "../models/ParsableType";
-import { ArrayUtils } from "../utils/array";
+import { distinct } from "../utils/array";
 
 export function makeCommand<T extends CommandDefinition>(
     name: string,
@@ -26,7 +26,7 @@ export function makeCommand<T extends CommandDefinition>(
         definition.rest.type.sort(sortParsableType);
 
     if (definition.clientPermissions)
-        (definition.clientPermissions as any) = ArrayUtils.distinct(
+        (definition.clientPermissions as any) = distinct(
             definition.clientPermissions
         );
 

--- a/src/other/parsing/parseArgs.ts
+++ b/src/other/parsing/parseArgs.ts
@@ -3,7 +3,7 @@ import { ParsableType } from "../../models/ParsableType";
 import { parseValue } from "./parseValue";
 import { ArgDefinition } from "../../models/definition/ArgDefinition";
 import { CommandResultUtils } from "../../models/CommandResult";
-import { CommandResultError } from "../../models/CommandResultError";
+import { CommandResultError } from "../../models/errors/CommandResultError";
 
 /** @internal */
 export function parseArgs(

--- a/src/other/parsing/parseFlags.ts
+++ b/src/other/parsing/parseFlags.ts
@@ -3,7 +3,7 @@ import { parseValue } from "./parseValue";
 import { Message } from "discord.js";
 import { ParsableDefinition } from "../../models/definition/ParsableDefinition";
 import { CommandResultUtils } from "../../models/CommandResult";
-import { CommandResultError } from "../../models/CommandResultError";
+import { CommandResultError } from "../../models/errors/CommandResultError";
 
 /** @internal */
 export function parseFlags(

--- a/src/other/parsing/parseValue.ts
+++ b/src/other/parsing/parseValue.ts
@@ -1,7 +1,7 @@
 import { Message, MessageMentions } from "discord.js";
 import { ParsableType } from "../../models/ParsableType";
 import { ParsableDefinition } from "../../models/definition/ParsableDefinition";
-import { ArrayUtils } from "../../utils/array";
+import { isArray } from "../../utils/array";
 
 /** @internal */
 const ID_PATTERN = /^\d{17,21}$/;
@@ -15,7 +15,7 @@ export function parseValue(
     argument: string
 ): { value: ParsableType | undefined; message?: string } {
     let value: ParsableType | undefined;
-    if (ArrayUtils.isArray(parseData.type)) {
+    if (isArray(parseData.type)) {
         for (const t of parseData.type) {
             value = parse(t, argument, message);
             if (value !== undefined) break;

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -1,9 +1,11 @@
 import path from "path";
 
+/** @internal */
 export function relativeFromEntryPoint(filepath: string) {
     return require.main ? path.relative(require.main.path, filepath) : filepath;
 }
 
+/** @internal */
 export function resolveFromEntryPoint(filepath: string) {
     return require.main ? path.resolve(require.main.path, filepath) : filepath;
 }

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -1,14 +1,9 @@
 import path from "path";
 
-export default {
-    relativeFromEntryPoint(filepath: string) {
-        return require.main
-            ? path.relative(require.main.path, filepath)
-            : filepath;
-    },
-    resolveFromEntryPoint(filepath: string) {
-        return require.main
-            ? path.resolve(require.main.path, filepath)
-            : filepath;
-    },
-};
+export function relativeFromEntryPoint(filepath: string) {
+    return require.main ? path.relative(require.main.path, filepath) : filepath;
+}
+
+export function resolveFromEntryPoint(filepath: string) {
+    return require.main ? path.resolve(require.main.path, filepath) : filepath;
+}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,7 +1,9 @@
+/** @internal */
 export function isArray(o: any): o is any[] | readonly any[] {
     return Array.isArray(o);
 }
 
+/** @internal */
 export function distinct<T>(a: T[]): T[] {
     return [...new Set(a)];
 }

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,9 +1,7 @@
-export abstract class ArrayUtils {
-    static isArray(o: any): o is any[] | readonly any[] {
-        return Array.isArray(o);
-    }
+export function isArray(o: any): o is any[] | readonly any[] {
+    return Array.isArray(o);
+}
 
-    static distinct<T>(a: T[]): T[] {
-        return [...new Set(a)];
-    }
+export function distinct<T>(a: T[]): T[] {
+    return [...new Set(a)];
 }

--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -1,20 +1,24 @@
-/** @ignore */
+/** @internal */
 function isObject(item: any) {
     return item && typeof item === "object" && !Array.isArray(item);
 }
 
+/** @internal */
 export function deepMerge<T, U>(target: T, source: U): T & U;
+/** @internal */
 export function deepMerge<T, U, V>(
     target: T,
     source1: U,
     source2: V
 ): T & U & V;
+/** @internal */
 export function deepMerge<T, U, V, W>(
     target: T,
     source1: U,
     source2: V,
     source3: W
 ): T & U & V & W;
+/** @internal */
 export function deepMerge(target: any, ...sources: any[]): any;
 /** @ignore */
 export function deepMerge(target: any, ...sources: any[]) {

--- a/src/utils/reply.ts
+++ b/src/utils/reply.ts
@@ -7,6 +7,7 @@ import {
     SplitOptions,
 } from "discord.js";
 
+/** @internal */
 export async function reply(
     message: Message,
     options:
@@ -15,6 +16,7 @@ export async function reply(
         | MessageAdditions
         | APIMessage
 ): Promise<Message>;
+/** @internal */
 export async function reply(
     message: Message,
     options:
@@ -24,6 +26,7 @@ export async function reply(
           })
         | APIMessage
 ): Promise<Message[]>;
+/** @internal */
 export async function reply(
     message: Message,
     content: StringResolvable,
@@ -32,6 +35,7 @@ export async function reply(
         | (MessageOptions & { split?: false })
         | MessageAdditions
 ): Promise<Message>;
+/** @internal */
 export async function reply(
     message: Message,
     content: StringResolvable,

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,3 +1,4 @@
+/** @internal */
 export function template(
     str: string,
     replaceValues: { [key: string]: string }

--- a/test/index.ts
+++ b/test/index.ts
@@ -12,7 +12,7 @@ const commands = new CommandSet({
 });
 
 commands.helpHandler = async (command, { message, options }) => {
-    const help = HelpUtils.Command.getRawHelp(command, options.localization);
+    const help = HelpUtils.commandRawHelp(command, options.localization);
     const text = `
 **Command name**: ${command.name}
 **Full name**: ${help.fullName}

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,9 +1,8 @@
 import { Client } from "discord.js";
-import { CommandSet, HelpUtils } from "../src/index";
-import { Logger } from "../src/logger";
+import { CommandSet, HelpUtils, enableDebugLogs } from "../src/index";
 import env from "./env.json";
 
-Logger.enableDebug = true;
+enableDebugLogs();
 
 const commands = new CommandSet({
     prefix: env.prefix,

--- a/test/log.ts
+++ b/test/log.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../src/logger";
+import { Logger, enableDebugLogs } from "../src/logger";
 import chalk from "chalk";
 
 Logger.log("Hello world");
@@ -6,5 +6,5 @@ Logger.warn("Hello world");
 Logger.error("Hello world");
 
 Logger.debug(chalk.bold.red("SHOULDN'T APPEAR !"));
-Logger.enableDebug = true;
+enableDebugLogs();
 Logger.debug("Hello world");


### PR DESCRIPTION


- resolve #91 : change architecture of utils file for consistency: remove `namespace`, `export default` and `static class`. 
- Mark all utils method as `@internal`.
- Rename `HelpCb` and `CanUseCommandCb` into `HelpHandler` and `CanUseCommandHandler`
- Move `CommandResultError` into errors sub dir.